### PR TITLE
Harden commit id extraction

### DIFF
--- a/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/LocalBuildCustomValueProvider.java
+++ b/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/LocalBuildCustomValueProvider.java
@@ -29,7 +29,7 @@ public class LocalBuildCustomValueProvider extends BuildScanCustomValueProvider 
             }
         }
 
-        GradleEnterpriseConventions.execAndGetStdout(settings.getRootDir(), "git", "log", "-1", "--format=%H")
+        GradleEnterpriseConventions.execAndGetStdout(settings.getRootDir(), "git", "rev-parse", "HEAD")
             .ifPresent(commitId -> getConventions().setCommitId(settings.getRootDir(), buildScan, commitId));
     }
 }


### PR DESCRIPTION
Prior to this, commit id extraction would fail if showSignature was active.
With this changes, we make sure it is turned off for the command run in this plugin.

Fixes #6

Unfortunately adding a proper test would require a setup that enables signing Git commits. Let me know if that is a must have.