### PR TITLE
Only configure build scan when url configured

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 rootProject.group = "com.gradle.enterprise"
-rootProject.version = "0.7.1"
+rootProject.version = "0.8-alpha1"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPlugin.java
+++ b/src/main/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPlugin.java
@@ -53,7 +53,9 @@ public abstract class GradleEnterpriseConventionsPlugin implements Plugin<Settin
             if (settings.getGradle().getStartParameter().isBuildCacheEnabled()) {
                 settings.buildCache(new BuildCacheConfigureAction(conventions));
             }
-            if (!settings.getGradle().getStartParameter().isNoBuildScan() && !containsPropertiesTask(settings)) {
+            if (!settings.getGradle().getStartParameter().isNoBuildScan()
+                && !containsPropertiesTask(settings)
+                && !conventions.getGradleEnterpriseServerUrl().isEmpty()) {
                 configureBuildScan(settings, conventions);
             }
         });

--- a/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/GradleEnterpriseConventions.java
+++ b/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/GradleEnterpriseConventions.java
@@ -28,7 +28,6 @@ import static com.gradle.enterprise.conventions.customvalueprovider.ScanCustomVa
 
 public class GradleEnterpriseConventions {
     private static final Logger LOGGER = Logging.getLogger(GradleEnterpriseConventions.class);
-    private static final String PUBLIC_GRADLE_ENTERPRISE_SERVER = "https://ge.gradle.org";
     private static final String GRADLE_ENTERPRISE_URL_PROPERTY_NAME = "gradle.enterprise.url";
     private static final String CI_ENV_NAME = "CI";
 
@@ -42,7 +41,7 @@ public class GradleEnterpriseConventions {
 
     public GradleEnterpriseConventions(ProviderFactory providerFactory) {
         this.providerFactory = providerFactory;
-        this.gradleEnterpriseServerUrl = getSystemProperty(GRADLE_ENTERPRISE_URL_PROPERTY_NAME, PUBLIC_GRADLE_ENTERPRISE_SERVER, providerFactory);
+        this.gradleEnterpriseServerUrl = getSystemProperty(GRADLE_ENTERPRISE_URL_PROPERTY_NAME, "", providerFactory);
         this.isCiServer = !providerFactory.environmentVariable(CI_ENV_NAME).forUseAtConfigurationTime().getOrElse("").isEmpty();
 
     }

--- a/src/test/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPluginIntegrationTest.java
+++ b/src/test/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPluginIntegrationTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class GradleEnterpriseConventionsPluginIntegrationTest extends AbstractGradleEnterprisePluginIntegrationTest {
     private static final String EU_CACHE_NODE = "https://eu-build-cache.gradle.org/cache/";
     private static final String US_CACHE_NODE = "https://us-build-cache.gradle.org/cache/";
-    private static final String PUBLIC_GRADLE_ENTERPRISE_SERVER = "https://ge.gradle.org";
 
     @Test
     public void configureBuildCacheOnlyWhenBuildCacheEnabled() throws URISyntaxException {
@@ -30,6 +29,7 @@ public class GradleEnterpriseConventionsPluginIntegrationTest extends AbstractGr
 
     @Test
     public void configureBuildScanButNotBuildCacheByDefault() {
+        withPublicGradleEnterpriseUrl();
         succeeds("help");
 
         assertNull(getConfiguredRemoteCache().getUrl());
@@ -42,6 +42,7 @@ public class GradleEnterpriseConventionsPluginIntegrationTest extends AbstractGr
 
     @Test
     public void configurePublishOnFailure() {
+        withPublicGradleEnterpriseUrl();
         succeeds("help", "-DpublishStrategy=publishOnFailure");
 
         assertNull(getConfiguredRemoteCache().getUrl());
@@ -53,7 +54,17 @@ public class GradleEnterpriseConventionsPluginIntegrationTest extends AbstractGr
     }
 
     @Test
+    public void disableBuildScanWithoutGEUrl() {
+        withEnvironmentVariable("CI", "1");
+
+        succeeds("help", "--no-scan");
+
+        assertNull(getConfiguredBuildScan().getServer());
+    }
+
+    @Test
     public void disableBuildScanWithNoBuildScan() {
+        withPublicGradleEnterpriseUrl();
         withEnvironmentVariable("CI", "1");
 
         succeeds("help", "--no-scan");
@@ -64,6 +75,7 @@ public class GradleEnterpriseConventionsPluginIntegrationTest extends AbstractGr
     @ParameterizedTest
     @ValueSource(strings = {"CI", "LOCAL"})
     public void disableBuildScanUponPropertiesTask(String env) {
+        withPublicGradleEnterpriseUrl();
         withEnvironmentVariable(env, "1");
 
         succeeds("properties");
@@ -73,6 +85,7 @@ public class GradleEnterpriseConventionsPluginIntegrationTest extends AbstractGr
 
     @Test
     public void disableBuildScanUpSubprojectPropertiesTask() {
+        withPublicGradleEnterpriseUrl();
         write("settings.gradle", "include(\"subprojectA\")");
         new File(projectDir, "subprojectA").mkdir();
 
@@ -84,6 +97,7 @@ public class GradleEnterpriseConventionsPluginIntegrationTest extends AbstractGr
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void configureBuildCacheViaSystemProperties(boolean configurationCacheEnabled) throws URISyntaxException {
+        withPublicGradleEnterpriseUrl();
         withEnvironmentVariable("CI", "1");
 
         succeeds("help", "--build-cache", "-DcacheNode=us", "-Dgradle.cache.remote.username=MyUsername", "-Dgradle.cache.remote.password=MyPassword", configurationCacheEnabled ? "--configuration-cache" : "--no-configuration-cache");

--- a/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/BuildCacheCustomValueProviderIntegrationTest.java
+++ b/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/BuildCacheCustomValueProviderIntegrationTest.java
@@ -12,6 +12,7 @@ public class BuildCacheCustomValueProviderIntegrationTest extends AbstractGradle
         "true", "false"
     })
     public void tagCachedIfBuildCacheEnabled(boolean buildCacheEnabled) {
+        withPublicGradleEnterpriseUrl();
         succeeds("help", buildCacheEnabled ? "--build-cache" : "--no-build-cache");
 
         assertEquals(buildCacheEnabled, getConfiguredBuildScan().containsTag("CACHED"));

--- a/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/CICustomValueProviderIntegrationTest.java
+++ b/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/CICustomValueProviderIntegrationTest.java
@@ -13,6 +13,7 @@ public class CICustomValueProviderIntegrationTest extends AbstractGradleEnterpri
     @BeforeEach
     public void setUp() {
         super.setUp();
+        withPublicGradleEnterpriseUrl();
         write("fileToCommit.txt", "hello");
         execAndGetStdout(projectDir, "git", "init");
         execAndGetStdout(projectDir, "git", "checkout", "-b", "new-branch");

--- a/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/GitInformationCustomValueProviderIntegrationTest.java
+++ b/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/GitInformationCustomValueProviderIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.gradle.enterprise.conventions.customvalueprovider;
 
 import com.gradle.enterprise.fixtures.AbstractGradleEnterprisePluginIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.gradle.enterprise.conventions.customvalueprovider.GradleEnterpriseConventions.execAndGetStdout;
@@ -8,6 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GitInformationCustomValueProviderIntegrationTest extends AbstractGradleEnterprisePluginIntegrationTest {
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        withPublicGradleEnterpriseUrl();
+    }
+
     @Test
     public void doNothingIfNotAGitRepo() {
         succeeds("help");

--- a/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/LocalBuildCustomValueProviderIntegrationTest.java
+++ b/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/LocalBuildCustomValueProviderIntegrationTest.java
@@ -1,12 +1,19 @@
 package com.gradle.enterprise.conventions.customvalueprovider;
 
 import com.gradle.enterprise.fixtures.AbstractGradleEnterprisePluginIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.gradle.enterprise.conventions.customvalueprovider.GradleEnterpriseConventions.execAndGetStdout;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LocalBuildCustomValueProviderIntegrationTest extends AbstractGradleEnterprisePluginIntegrationTest {
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        withPublicGradleEnterpriseUrl();
+    }
+
     @Test
     public void tagIDEAVersionIfAvailable() {
         succeeds("help", "-Didea.active", "-Didea.paths.selector=2020.1");

--- a/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/WatchFilesystemCustomValueProviderIntegrationTest.java
+++ b/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/WatchFilesystemCustomValueProviderIntegrationTest.java
@@ -12,6 +12,7 @@ public class WatchFilesystemCustomValueProviderIntegrationTest extends AbstractG
         "true", "false"
     })
     public void addWatchFsCustomValue(Boolean watchFsEnabled) {
+        withPublicGradleEnterpriseUrl();
         succeeds("help", watchFsEnabled ? "--watch-fs" : "--no-watch-fs");
 
         assertTrue(getConfiguredBuildScan().containsValue("watchFileSystem", watchFsEnabled.toString()));


### PR DESCRIPTION
So that community members can publish build scan to `scans.gradle.com`.