### PR TITLE
Support publishing build scan to public GE if not authenticated

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ When applied as a settings plugin alongside the [Gradle Enterprise Plugin](https
   - Enable [ge.gradle.org](https://ge.gradle.org) as remote cache and anonymous read access, enjoy faster build!
     - There're three build cache node available on the earth: `eu`(the default)/`us`/`au`, you can use `-DcacheNode=us`/`-DcacheNode=au` to use other ones.
   - Enable pushing to remote cache on CI if required credentials are provided.
-- Build scans are published to private GE server if credentials are provided, or public instance (`gradle.com`) if not authenticated.
+- Build scans are published to private GE server if credentials are provided, or public instance (`scan.gradle.com`) if not authenticated.
   - For CI build (`CI` environment variable exists):
     - Add `CI` build scan tag.
     - Add build scan link and build scan custom value `gitCommitId` to the build (by auto detecting environment variables):
@@ -41,7 +41,6 @@ When applied as a settings plugin alongside the [Gradle Enterprise Plugin](https
 The plugin is published to gradle plugin portal.
 
 This is done by configuring a plugin management repository in `settings.gradle`, as shown in the following example:
-
 
 ```
 plugins {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ When applied as a settings plugin alongside the [Gradle Enterprise Plugin](https
   - Enable [ge.gradle.org](https://ge.gradle.org) as remote cache and anonymous read access, enjoy faster build!
     - There're three build cache node available on the earth: `eu`(the default)/`us`/`au`, you can use `-DcacheNode=us`/`-DcacheNode=au` to use other ones.
   - Enable pushing to remote cache on CI if required credentials are provided.
-- Build scans are published to private GE server if credentials are provided, or public instance (`scan.gradle.com`) if not authenticated.
+- By default, build scans are published to `ge.gradle.org`. If you would like to publish to your own GE server, add `-Dgradle.enterprise.url=https://ge.mycompany.com/`.
+  If you would like to publish to public build scan server (`scan.gradle.com`), add `-DagreePublicBuildScanTermOfService=yes` to your build.
   - For CI build (`CI` environment variable exists):
     - Add `CI` build scan tag.
     - Add build scan link and build scan custom value `gitCommitId` to the build (by auto detecting environment variables):

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ When applied as a settings plugin alongside the [Gradle Enterprise Plugin](https
   - Enable [ge.gradle.org](https://ge.gradle.org) as remote cache and anonymous read access, enjoy faster build!
     - There're three build cache node available on the earth: `eu`(the default)/`us`/`au`, you can use `-DcacheNode=us`/`-DcacheNode=au` to use other ones.
   - Enable pushing to remote cache on CI if required credentials are provided.
-- Enable build scan publishing if required credentials are provided.
+- Build scans are published to private GE server if credentials are provided, or public instance (`gradle.com`) if not authenticated.
   - For CI build (`CI` environment variable exists):
     - Add `CI` build scan tag.
     - Add build scan link and build scan custom value `gitCommitId` to the build (by auto detecting environment variables):

--- a/src/main/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPlugin.java
+++ b/src/main/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPlugin.java
@@ -28,7 +28,6 @@ import static com.gradle.enterprise.conventions.customvalueprovider.CIBuildCusto
 import static com.gradle.enterprise.conventions.customvalueprovider.CIBuildCustomValueProvider.TravisCustomValueProvider;
 
 public abstract class GradleEnterpriseConventionsPlugin implements Plugin<Settings> {
-
     private List<BuildScanCustomValueProvider> createBuildScanCustomValueProviders(GradleEnterpriseConventions conventions) {
         return Arrays.asList(
             new BuildCacheCustomValueProvider(conventions),
@@ -69,6 +68,7 @@ public abstract class GradleEnterpriseConventionsPlugin implements Plugin<Settin
     private void configureBuildScan(Settings settings, GradleEnterpriseConventions conventions) {
         BuildScanExtension buildScan = settings.getExtensions().getByType(GradleEnterpriseExtension.class).getBuildScan();
 
+        // This means `-DagreePublicBuildScanTermOfService=yes` is present
         if (conventions.getGradleEnterpriseServerUrl() == null) {
             buildScan.setTermsOfServiceUrl("https://gradle.com/terms-of-service");
             buildScan.setTermsOfServiceAgree("yes");

--- a/src/main/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPlugin.java
+++ b/src/main/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPlugin.java
@@ -18,7 +18,6 @@ import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.caching.http.HttpBuildCache;
 
 import javax.inject.Inject;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -69,7 +68,12 @@ public abstract class GradleEnterpriseConventionsPlugin implements Plugin<Settin
     private void configureBuildScan(Settings settings, GradleEnterpriseConventions conventions) {
         BuildScanExtension buildScan = settings.getExtensions().getByType(GradleEnterpriseExtension.class).getBuildScan();
 
-        buildScan.setServer(conventions.getGradleEnterpriseServerUrl());
+        if (conventions.getGradleEnterpriseServerUrl() == null) {
+            buildScan.setTermsOfServiceUrl("https://gradle.com/terms-of-service");
+            buildScan.setTermsOfServiceAgree("yes");
+        } else {
+            buildScan.setServer(conventions.getGradleEnterpriseServerUrl());
+        }
         buildScan.setCaptureTaskInputFiles(true);
         configurePublishStrategy(conventions, buildScan);
         try {
@@ -94,12 +98,6 @@ public abstract class GradleEnterpriseConventionsPlugin implements Plugin<Settin
                 break;
             default:
                 throw new IllegalStateException("Unknown strategy: " + strategy);
-        }
-
-        try {
-            buildScan.getClass().getMethod("publishIfAuthenticated").invoke(buildScan);
-        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-            throw new IllegalStateException("Could not call publishIfAuthenticated()", e);
         }
     }
 

--- a/src/main/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPlugin.java
+++ b/src/main/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPlugin.java
@@ -18,6 +18,7 @@ import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.caching.http.HttpBuildCache;
 
 import javax.inject.Inject;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -73,6 +74,7 @@ public abstract class GradleEnterpriseConventionsPlugin implements Plugin<Settin
             buildScan.setTermsOfServiceAgree("yes");
         } else {
             buildScan.setServer(conventions.getGradleEnterpriseServerUrl());
+            publishIfAuthenticated(buildScan);
         }
         buildScan.setCaptureTaskInputFiles(true);
         configurePublishStrategy(conventions, buildScan);
@@ -85,6 +87,14 @@ public abstract class GradleEnterpriseConventionsPlugin implements Plugin<Settin
         createBuildScanCustomValueProviders(conventions).stream()
             .filter(BuildScanCustomValueProvider::isEnabled)
             .forEach(it -> it.accept(settings, buildScan));
+    }
+
+    private void publishIfAuthenticated(BuildScanExtension buildScan) {
+        try {
+            buildScan.getClass().getMethod("publishIfAuthenticated").invoke(buildScan);
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new IllegalStateException("Could not call publishIfAuthenticated()", e);
+        }
     }
 
     private void configurePublishStrategy(GradleEnterpriseConventions conventions, BuildScanExtension buildScan) {

--- a/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/CIBuildCustomValueProvider.java
+++ b/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/CIBuildCustomValueProvider.java
@@ -33,7 +33,7 @@ public abstract class CIBuildCustomValueProvider extends BuildScanCustomValuePro
             String commitId = getConventions().getEnv("GITHUB_SHA");
             buildScan.value(BUILD_ID, String.format("%s %s", getConventions().getEnv("GITHUB_RUN_ID"), getConventions().getEnv("GITHUB_RUN_NUMBER")));
             buildScan.value(GIT_COMMIT_NAME, commitId);
-            buildScan.link("Git Commit Scans", getConventions().customValueSearchUrl(Collections.singletonMap(GIT_COMMIT_NAME, commitId)));
+            getConventions().customValueSearchUrl(Collections.singletonMap(GIT_COMMIT_NAME, commitId)).ifPresent(url -> buildScan.link("Git Commit Scans", url));
             buildScan.background(__ ->
                 getRemoteGitHubRepository(settings.getRootDir()).ifPresent(repoUrl -> {
                     buildScan.link("GitHub Actions Build", String.format("%s/runs/%s", repoUrl, getConventions().getEnv("GITHUB_RUN_ID")));

--- a/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/GitInformationCustomValueProvider.java
+++ b/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/GitInformationCustomValueProvider.java
@@ -25,8 +25,15 @@ public class GitInformationCustomValueProvider extends BuildScanCustomValueProvi
                         buildScan.value(GIT_STATUS, output);
                     }
                 });
-            execAndGetStdout(rootDir, "git", "rev-parse", "--abbrev-ref", "HEAD")
-                .ifPresent(output -> buildScan.value(GIT_BRANCH_NAME, output));
+
+            // https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+            String gitHubBranch = System.getenv("GITHUB_HEAD_REF");
+            if (gitHubBranch != null) {
+                buildScan.value(GIT_BRANCH_NAME, gitHubBranch);
+            } else {
+                execAndGetStdout(rootDir, "git", "rev-parse", "--abbrev-ref", "HEAD")
+                    .ifPresent(output -> buildScan.value(GIT_BRANCH_NAME, output));
+            }
         });
     }
 }

--- a/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/GitInformationCustomValueProvider.java
+++ b/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/GitInformationCustomValueProvider.java
@@ -27,9 +27,12 @@ public class GitInformationCustomValueProvider extends BuildScanCustomValueProvi
                 });
 
             // https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-            String gitHubBranch = System.getenv("GITHUB_HEAD_REF");
-            if (gitHubBranch != null) {
-                buildScan.value(GIT_BRANCH_NAME, gitHubBranch);
+            String githubRef = System.getenv("GITHUB_REF");
+            String githubHeadRef = System.getenv("GITHUB_HEAD_REF");
+            if (githubRef != null) {
+                buildScan.value(GIT_BRANCH_NAME, githubRef);
+            } else if (githubHeadRef != null) {
+                buildScan.value(GIT_BRANCH_NAME, githubHeadRef);
             } else {
                 execAndGetStdout(rootDir, "git", "rev-parse", "--abbrev-ref", "HEAD")
                     .ifPresent(output -> buildScan.value(GIT_BRANCH_NAME, output));

--- a/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/GradleEnterpriseConventions.java
+++ b/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/GradleEnterpriseConventions.java
@@ -62,7 +62,7 @@ public class GradleEnterpriseConventions {
     private boolean isAuthenticatedForDefaultGEServer() {
         Provider<String> geAccessKey = providerFactory.environmentVariable(GRADLE_ENTERPRISE_ACCESS_KEY).forUseAtConfigurationTime();
         return geAccessKey.isPresent() &&
-            (geAccessKey.get().startsWith(DEFAULT_GRADLE_ENTERPRISE_SERVER + "=") || geAccessKey.get().contains(";" + GRADLE_ENTERPRISE_ACCESS_KEY + "="));
+            (geAccessKey.get().startsWith(DEFAULT_GRADLE_ENTERPRISE_SERVER + "=") || geAccessKey.get().contains(";" + DEFAULT_GRADLE_ENTERPRISE_SERVER + "="));
     }
 
     public Optional<String> customValueSearchUrl(Map<String, String> search) {

--- a/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/GradleEnterpriseConventions.java
+++ b/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/GradleEnterpriseConventions.java
@@ -28,8 +28,8 @@ import static com.gradle.enterprise.conventions.customvalueprovider.ScanCustomVa
 
 public class GradleEnterpriseConventions {
     private static final Logger LOGGER = Logging.getLogger(GradleEnterpriseConventions.class);
-    private static final String DEFAULT_GRADLE_ENTERPRISE_SERVER = "ge.gradle.org";
-    private static final String GRADLE_ENTERPRISE_ACCESS_KEY = "GRADLE_ENTERPRISE_ACCESS_KEY";
+    private static final String DEFAULT_GRADLE_ENTERPRISE_SERVER = "https://ge.gradle.org";
+    private static final String AGREE_PUBLIC_BUILD_SCAN_TERM_OF_SERVICE = "agreePublicBuildScanTermOfService";
     private static final String GRADLE_ENTERPRISE_URL_PROPERTY_NAME = "gradle.enterprise.url";
     private static final String CI_ENV_NAME = "CI";
 
@@ -49,20 +49,15 @@ public class GradleEnterpriseConventions {
 
     private String determineGradleEnterpriseUrl() {
         Provider<String> geServerUrl = providerFactory.systemProperty(GRADLE_ENTERPRISE_URL_PROPERTY_NAME).forUseAtConfigurationTime();
+        Provider<String> agreePublicBuildScanTermOfService = providerFactory.systemProperty(AGREE_PUBLIC_BUILD_SCAN_TERM_OF_SERVICE).forUseAtConfigurationTime();
         if (geServerUrl.isPresent()) {
             return geServerUrl.get();
-        } else if (isAuthenticatedForDefaultGEServer()) {
-            return "https://" + DEFAULT_GRADLE_ENTERPRISE_SERVER;
-        } else {
+        } else if ("yes".equals(agreePublicBuildScanTermOfService.getOrElse("no"))) {
             // So that we can publish to default GE instance (https://gradle.com)
             return null;
+        } else {
+            return DEFAULT_GRADLE_ENTERPRISE_SERVER;
         }
-    }
-
-    private boolean isAuthenticatedForDefaultGEServer() {
-        Provider<String> geAccessKey = providerFactory.environmentVariable(GRADLE_ENTERPRISE_ACCESS_KEY).forUseAtConfigurationTime();
-        return geAccessKey.isPresent() &&
-            (geAccessKey.get().startsWith(DEFAULT_GRADLE_ENTERPRISE_SERVER + "=") || geAccessKey.get().contains(";" + DEFAULT_GRADLE_ENTERPRISE_SERVER + "="));
     }
 
     public Optional<String> customValueSearchUrl(Map<String, String> search) {

--- a/src/test/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPluginIntegrationTest.java
+++ b/src/test/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPluginIntegrationTest.java
@@ -29,12 +29,39 @@ public class GradleEnterpriseConventionsPluginIntegrationTest extends AbstractGr
     }
 
     @Test
-    public void configureBuildScanButNotBuildCacheByDefault() {
+    public void configureBuildScanForPublicServer() {
+        succeeds("help");
+
+        assertNull(getConfiguredRemoteCache().getUrl());
+        assertTrue(getConfiguredBuildScan().isCaptureTaskInputFiles());
+        assertFalse(getConfiguredBuildScan().isPublishIfAuthenticated());
+        assertTrue(getConfiguredBuildScan().isUploadInBackground());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "ge.gradle.org=ABC",
+        "ge.gradle.org=ABC;ge-experimental.grdev.net=DEF",
+        "ge-experimental.grdev.net=ABC;ge.gradle.org=DEF"}
+    )
+    public void configureDefaultGEServerIfAuthenticated(String env) {
+        withEnvironmentVariable("GRADLE_ENTERPRISE_ACCESS_KEY", env);
         succeeds("help");
 
         assertNull(getConfiguredRemoteCache().getUrl());
         assertEquals(PUBLIC_GRADLE_ENTERPRISE_SERVER, getConfiguredBuildScan().getServer());
+        assertTrue(getConfiguredBuildScan().isCaptureTaskInputFiles());
+        assertTrue(getConfiguredBuildScan().isPublishIfAuthenticated());
+        assertTrue(getConfiguredBuildScan().isUploadInBackground());
+    }
+
+    @Test
+    public void configureBuildScanButNotBuildCacheByDefault() {
+        succeeds("help", "-Dgradle.enterprise.url=https://ge.gradle.org");
+
+        assertNull(getConfiguredRemoteCache().getUrl());
         assertTrue(getConfiguredBuildScan().isPublishAlways());
+        assertEquals(PUBLIC_GRADLE_ENTERPRISE_SERVER, getConfiguredBuildScan().getServer());
         assertTrue(getConfiguredBuildScan().isCaptureTaskInputFiles());
         assertTrue(getConfiguredBuildScan().isPublishIfAuthenticated());
         assertTrue(getConfiguredBuildScan().isUploadInBackground());
@@ -42,11 +69,11 @@ public class GradleEnterpriseConventionsPluginIntegrationTest extends AbstractGr
 
     @Test
     public void configurePublishOnFailure() {
-        succeeds("help", "-DpublishStrategy=publishOnFailure");
+        succeeds("help", "-DpublishStrategy=publishOnFailure", "-Dgradle.enterprise.url=https://ge.gradle.org");
 
         assertNull(getConfiguredRemoteCache().getUrl());
-        assertEquals(PUBLIC_GRADLE_ENTERPRISE_SERVER, getConfiguredBuildScan().getServer());
         assertTrue(getConfiguredBuildScan().isPublishOnFailure());
+        assertEquals(PUBLIC_GRADLE_ENTERPRISE_SERVER, getConfiguredBuildScan().getServer());
         assertTrue(getConfiguredBuildScan().isCaptureTaskInputFiles());
         assertTrue(getConfiguredBuildScan().isPublishIfAuthenticated());
         assertTrue(getConfiguredBuildScan().isUploadInBackground());

--- a/src/test/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPluginIntegrationTest.java
+++ b/src/test/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPluginIntegrationTest.java
@@ -29,35 +29,19 @@ public class GradleEnterpriseConventionsPluginIntegrationTest extends AbstractGr
     }
 
     @Test
-    public void configureBuildScanForPublicServer() {
-        succeeds("help");
+    public void configurePublicBuildScanServerIfAgreePublicBuildScanTermOfService() {
+        succeeds("help", "-DagreePublicBuildScanTermOfService=yes");
 
         assertNull(getConfiguredRemoteCache().getUrl());
+        assertNull(getConfiguredBuildScan().getServer());
         assertTrue(getConfiguredBuildScan().isCaptureTaskInputFiles());
         assertFalse(getConfiguredBuildScan().isPublishIfAuthenticated());
         assertTrue(getConfiguredBuildScan().isUploadInBackground());
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {
-        "ge.gradle.org=ABC",
-        "ge.gradle.org=ABC;ge-experimental.grdev.net=DEF",
-        "ge-experimental.grdev.net=ABC;ge.gradle.org=DEF"}
-    )
-    public void configureDefaultGEServerIfAuthenticated(String env) {
-        withEnvironmentVariable("GRADLE_ENTERPRISE_ACCESS_KEY", env);
-        succeeds("help");
-
-        assertNull(getConfiguredRemoteCache().getUrl());
-        assertEquals(PUBLIC_GRADLE_ENTERPRISE_SERVER, getConfiguredBuildScan().getServer());
-        assertTrue(getConfiguredBuildScan().isCaptureTaskInputFiles());
-        assertTrue(getConfiguredBuildScan().isPublishIfAuthenticated());
-        assertTrue(getConfiguredBuildScan().isUploadInBackground());
-    }
-
     @Test
     public void configureBuildScanButNotBuildCacheByDefault() {
-        succeeds("help", "-Dgradle.enterprise.url=https://ge.gradle.org");
+        succeeds("help");
 
         assertNull(getConfiguredRemoteCache().getUrl());
         assertTrue(getConfiguredBuildScan().isPublishAlways());

--- a/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/CICustomValueProviderIntegrationTest.java
+++ b/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/CICustomValueProviderIntegrationTest.java
@@ -31,7 +31,7 @@ public class CICustomValueProviderIntegrationTest extends AbstractGradleEnterpri
         withEnvironmentVariable("BUILD_ID", "jenkins_id");
         withEnvironmentVariable("GIT_COMMIT", headCommitId);
 
-        succeeds("help");
+        succeeds("help", "-Dgradle.enterprise.url=https://ge.gradle.org");
 
         assertTrue(getConfiguredBuildScan().containsLink("Jenkins Build", "https://jenkins"));
         assertTrue(getConfiguredBuildScan().containsValue("buildId", "jenkins_id"));
@@ -46,7 +46,7 @@ public class CICustomValueProviderIntegrationTest extends AbstractGradleEnterpri
         withEnvironmentVariable("BUILD_ID", "teamcity_id");
         withEnvironmentVariable("BUILD_VCS_NUMBER", headCommitId);
 
-        succeeds("help");
+        succeeds("help", "-Dgradle.enterprise.url=https://ge.gradle.org");
 
         assertTrue(getConfiguredBuildScan().containsLink("TeamCity Build", "https://teamcity"));
         assertTrue(getConfiguredBuildScan().containsValue("buildId", "teamcity_id"));
@@ -61,7 +61,7 @@ public class CICustomValueProviderIntegrationTest extends AbstractGradleEnterpri
         withEnvironmentVariable("TRAVIS_BUILD_ID", "travis_id");
         withEnvironmentVariable("TRAVIS_COMMIT", headCommitId);
 
-        succeeds("help");
+        succeeds("help", "-Dgradle.enterprise.url=https://ge.gradle.org");
 
         assertTrue(getConfiguredBuildScan().containsLink("Travis Build", "https://travis"));
         assertTrue(getConfiguredBuildScan().containsValue("buildId", "travis_id"));
@@ -74,11 +74,13 @@ public class CICustomValueProviderIntegrationTest extends AbstractGradleEnterpri
         withEnvironmentVariable("GITHUB_ACTIONS", "1");
         withEnvironmentVariable("GITHUB_RUN_ID", "123");
         withEnvironmentVariable("GITHUB_RUN_NUMBER", "456");
+        withEnvironmentVariable("GITHUB_HEAD_REF", "myBranch");
         withEnvironmentVariable("GITHUB_SHA", headCommitId);
 
-        succeeds("help");
+        succeeds("help", "-Dgradle.enterprise.url=https://ge.gradle.org");
 
         assertTrue(getConfiguredBuildScan().containsValue("buildId", "123 456"));
+        assertTrue(getConfiguredBuildScan().containsBackgroundValue("gitBranchName", "myBranch"));
         assertTrue(getConfiguredBuildScan().containsBackgroundLink("GitHub Actions Build", "https://github.com/gradle/gradle/runs/123"));
         verifyGitCommitInformation();
     }


### PR DESCRIPTION
Previously, if GE server was not configured, it will be automatically
configured as "ge.gradle.org". Some community members complain because
they want to publish to public GE if not authenticated. Now the logic
is changed to:

- If server url is set explicitly, use it.
- Otherwise, if current build is authenticated for ge.gradle.org, use
  it.
- Otherwise, don't set GE server url so we can publish to public GE.

This is not perfect because it doesn't take `~/.gradle/enterprise`
authentication into account, but still better than before.