### PR TITLE
Add GitHub actions link

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 rootProject.group = "com.gradle.enterprise"
-rootProject.version = "0.7.4"
+rootProject.version = "0.7.5"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/GradleEnterpriseConventions.java
+++ b/src/main/java/com/gradle/enterprise/conventions/customvalueprovider/GradleEnterpriseConventions.java
@@ -127,7 +127,11 @@ public class GradleEnterpriseConventions {
 
         buildScan.value(GIT_COMMIT_NAME, commitId);
         customValueSearchUrl(Collections.singletonMap(GIT_COMMIT_NAME, commitId)).ifPresent(url -> buildScan.link("Git Commit Scans", url));
-        buildScan.background(__ -> getRemoteGitHubRepository(projectDir).ifPresent(repoUrl -> buildScan.link("Source", String.format("%s/commit/%s", repoUrl, commitId))));
+        if (isCiServer) {
+            getRemoteGitHubRepository(projectDir).ifPresent(repoUrl -> buildScan.link("Source", String.format("%s/commit/%s", repoUrl, commitId)));
+        } else {
+            buildScan.background(__ -> getRemoteGitHubRepository(projectDir).ifPresent(repoUrl -> buildScan.link("Source", String.format("%s/commit/%s", repoUrl, commitId))));
+        }
     }
 
     private static String toString(InputStream is) {

--- a/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/CICustomValueProviderIntegrationTest.java
+++ b/src/test/java/com/gradle/enterprise/conventions/customvalueprovider/CICustomValueProviderIntegrationTest.java
@@ -75,19 +75,20 @@ public class CICustomValueProviderIntegrationTest extends AbstractGradleEnterpri
         withEnvironmentVariable("GITHUB_RUN_ID", "123");
         withEnvironmentVariable("GITHUB_RUN_NUMBER", "456");
         withEnvironmentVariable("GITHUB_HEAD_REF", "myBranch");
+        withEnvironmentVariable("GITHUB_REPOSITORY", "gradle/gradle");
         withEnvironmentVariable("GITHUB_SHA", headCommitId);
 
         succeeds("help", "-Dgradle.enterprise.url=https://ge.gradle.org");
 
         assertTrue(getConfiguredBuildScan().containsValue("buildId", "123 456"));
         assertTrue(getConfiguredBuildScan().containsBackgroundValue("gitBranchName", "myBranch"));
-        assertTrue(getConfiguredBuildScan().containsBackgroundLink("GitHub Actions Build", "https://github.com/gradle/gradle/runs/123"));
+        assertTrue(getConfiguredBuildScan().containsLink("GitHub Actions Build", "https://github.com/gradle/gradle/actions/runs/123"));
         verifyGitCommitInformation();
     }
 
     private void verifyGitCommitInformation() {
         assertTrue(getConfiguredBuildScan().containsValue("gitCommitId", headCommitId));
-        assertTrue(getConfiguredBuildScan().containsBackgroundLink("Source", String.format("https://github.com/gradle/gradle/commit/%s", headCommitId)));
+        assertTrue(getConfiguredBuildScan().containsLink("Source", String.format("https://github.com/gradle/gradle/commit/%s", headCommitId)));
         assertTrue(getConfiguredBuildScan().containsLink("Git Commit Scans", "https://ge.gradle.org/scans?search.names=gitCommitId&search.values=" + headCommitId));
     }
 }


### PR DESCRIPTION
Don't use background upload for CI builds.

CI links seem to me missing on GitHub, probably because of background upload.